### PR TITLE
Replace strcpy() for overlapping string operation

### DIFF
--- a/info.c
+++ b/info.c
@@ -108,7 +108,7 @@ void Info_RemoveKey (char *s, const char *key)
 
 		if (!strcmp (key, pkey))
 		{
-			strcpy (start, s);	// FIXME: remove this part
+			memmove(start, s, strlen(s) + 1);
 			return;
 		}
 


### PR DESCRIPTION
[First commit replaced with Q_strcpy() from ezquake, @fzwoch pointed out memmove() was cleaner].

Userinfo strings were becoming corrupted when removing a key from the string, causing players to disappear from qtv, spectators appearing as players, and/or players appearing but having default/blank names & colours.

Bug must depend on strcpy implementation - couldn't replicate in Windows.
In Linux:
 - Connect qtv to server
 - Connect client to server
 - Check qtv/nowplaying - player should appear as normal
 - Change color/team/name (bug only happens when changing a key that was already in the userinfo and wasn't the last key/value pair in the string)
 - Check qtv/nowplaying - player entry should have one of the symptoms above